### PR TITLE
Assign NODE_PATH without trailing slash and ensure its added everywhere else

### DIFF
--- a/scripts/cold_register
+++ b/scripts/cold_register
@@ -49,7 +49,7 @@ function submit_stake_addr {
 
 # Check for staking-hot.tar.gz
 if [ ! -f "${NODE_PATH}/staking-hot.tar.gz" ]; then
-    echo "Missing required ${NODE_PATH}staking-hot.tar.gz file. First run with the \`--cold-register\` argument on a secure offline node."
+    echo "Missing required ${NODE_PATH}/staking-hot.tar.gz file. First run with the \`--cold-register\` argument on a secure offline node."
     read -n 1 -r -s -p "If you already have generated the file, please place it in its correct place, and press ENTER to continue."
 fi
 
@@ -99,7 +99,7 @@ then
 else
     echo "Transaction has been submitted to the blockchain."
     echo ${OUT}
-    
+
     echo "Wait for blockchain to register the pool"
     wait_for_pool_registration
     echo "Your stake pool registration has been sent to the blockchain."

--- a/scripts/init_node_vars
+++ b/scripts/init_node_vars
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export NODE_PATH=/config/${CARDANO_NETWORK}-${NODE_NAME}/
+export NODE_PATH=/config/${CARDANO_NETWORK}-${NODE_NAME}
 if [[ "${CARDANO_NODE_SOCKET_PATH}" == "DEFAULT" ]]; then
-    export CARDANO_NODE_SOCKET_PATH=${NODE_PATH}node.socket
+    export CARDANO_NODE_SOCKET_PATH=${NODE_PATH}/node.socket
 fi
 source /cfg-templates/${CARDANO_NETWORK}/VARS

--- a/scripts/leaderlogs.sh
+++ b/scripts/leaderlogs.sh
@@ -3,15 +3,15 @@
 source /scripts/init_node_vars
 
 # Init vars
-POOL_ID=$(cat ${NODE_PATH}staking/POOL_ID)
+POOL_ID=$(cat ${NODE_PATH}/staking/POOL_ID)
 TZ=$(cat /etc/timezone)
-VRF=${NODE_PATH}staking/pool-keys/vrf.skey
+VRF=${NODE_PATH}/staking/pool-keys/vrf.skey
 
 echo "Dumping ledger.json"
-cardano-cli query ledger-state --allegra-era ${NETWORK_ARGUMENT} --out-file ${NODE_PATH}ledger.json
+cardano-cli query ledger-state --allegra-era ${NETWORK_ARGUMENT} --out-file ${NODE_PATH}/ledger.json
 
 echo "Calculating sigma"
-SIGMA=$(python3 /scripts/pooltool.io/leaderLogs/getSigma.py --pool-id ${POOL_ID} --ledger ${NODE_PATH}ledger.json | tail -1 | awk '{print $2}')
+SIGMA=$(python3 /scripts/pooltool.io/leaderLogs/getSigma.py --pool-id ${POOL_ID} --ledger ${NODE_PATH}/ledger.json | tail -1 | awk '{print $2}')
 
 # Print vars
 echo "POOL_ID: ${SIGMA}"


### PR DESCRIPTION
I found over 100 cases where a slash was added `${NODE_PATH}/...` so I chose to remove it when assigning the env var and add the slash in the few places where it was missing.