### PR TITLE
Cardano node 1.26.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.25.1"
+VERSION="1.26.1"
 docker build \
     --build-arg VERSION=${VERSION} \
     --tag arradev/cardano-node:${VERSION} \

--- a/cfg-templates/main/VARS
+++ b/cfg-templates/main/VARS
@@ -1,3 +1,2 @@
 export NETWORK_ARGUMENT="--mainnet"
-export ERA_ARGUMENT="--mary-era"
 export HARDFORK_EPOCH=208

--- a/cfg-templates/mc4/VARS
+++ b/cfg-templates/mc4/VARS
@@ -1,3 +1,2 @@
 export NETWORK_ARGUMENT="--testnet-magic 42"
-export ERA_ARGUMENT="--mary-era"
 export HARDFORK_EPOCH=1

--- a/cfg-templates/test/VARS
+++ b/cfg-templates/test/VARS
@@ -1,3 +1,2 @@
 export NETWORK_ARGUMENT="--testnet-magic 1097911063"
-export ERA_ARGUMENT="--mary-era"
 export HARDFORK_EPOCH=1

--- a/scripts/functions/check_address_registration
+++ b/scripts/functions/check_address_registration
@@ -2,5 +2,5 @@ function check_address_registration {
     source /scripts/init_node_vars
 
     STAKE_ADDR=$1
-    cardano-cli query stake-address-info --address ${STAKE_ADDR} ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} | grep -v {}
+    cardano-cli query stake-address-info --address ${STAKE_ADDR} ${NETWORK_ARGUMENT} | grep -v {}
 }

--- a/scripts/functions/check_balance
+++ b/scripts/functions/check_balance
@@ -8,9 +8,9 @@ function check_balance {
             echo ""
 
             TOTAL_LOVELACE=0
-            cardano-cli query utxo ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} --address ${ADDRESS}
+            cardano-cli query utxo ${NETWORK_ARGUMENT} --address ${ADDRESS}
 
-            UTXOS=$(cardano-cli query utxo ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} --address ${ADDRESS} | tail -n +3)
+            UTXOS=$(cardano-cli query utxo ${NETWORK_ARGUMENT} --address ${ADDRESS} | tail -n +3)
             echo "UTXO#TXIX: LOVELACE"
             while IFS= read -r line ; do
                 arr=(${line})
@@ -49,7 +49,7 @@ function check_balance {
         done
     else
         echo "Find UTXO and TXIX containing atleast ${PRICE} Lovelace for address ${ADDRESS} (Wallet ${WALLET})"
-        echo "Run \`cardano-cli query utxo ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} --address ${ADDRESS}\`, on online node to find the values."
+        echo "Run \`cardano-cli query utxo ${NETWORK_ARGUMENT} --address ${ADDRESS}\`, on online node to find the values."
         read -p "Enter the UTXO: " UTXO
         read -p "Enter the TXIX: " TXIX
         LOVELACE=0

--- a/scripts/functions/check_pool_registration
+++ b/scripts/functions/check_pool_registration
@@ -2,5 +2,5 @@ function check_pool_registration {
     source /scripts/init_node_vars
 
     POOL_ID=$(cat ${NODE_PATH}/staking/POOL_ID)
-    cardano-cli query ledger-state ${ERA_ARGUMENT} ${NETWORK_ARGUMENT} | grep publicKey | grep ${POOL_ID}
+    cardano-cli query ledger-state ${NETWORK_ARGUMENT} | grep publicKey | grep ${POOL_ID}
 }

--- a/scripts/functions/get_block
+++ b/scripts/functions/get_block
@@ -2,5 +2,5 @@
 
 source /scripts/init_node_vars
 
-BLOCK=$(cardano-cli query tip ${NETWORK_ARGUMENT} | jq -r '.blockNo')
+BLOCK=$(cardano-cli query tip ${NETWORK_ARGUMENT} | jq -r '.block')
 echo "${BLOCK}"

--- a/scripts/functions/get_protocol
+++ b/scripts/functions/get_protocol
@@ -3,4 +3,4 @@
 # Init vars
 source /scripts/init_node_vars
 
-cardano-cli query protocol-parameters ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} --out-file protocol.json
+cardano-cli query protocol-parameters ${NETWORK_ARGUMENT} --out-file protocol.json

--- a/scripts/functions/get_slot
+++ b/scripts/functions/get_slot
@@ -2,5 +2,5 @@
 
 source /scripts/init_node_vars
 
-SLOT=$(cardano-cli query tip ${NETWORK_ARGUMENT} | jq -r '.slotNo')
+SLOT=$(cardano-cli query tip ${NETWORK_ARGUMENT} | jq -r '.slot')
 echo "${SLOT}"

--- a/scripts/functions/sync_status
+++ b/scripts/functions/sync_status
@@ -18,7 +18,7 @@ byron_slots=$(($HARDFORK_EPOCH * byron_epoch_length))
 now=$(date +'%s')
 
 expected_slot=$((byron_slots + (now - byron_end) / slot_length))
-current_slot=$(cardano-cli query tip $NETWORK_ARGUMENT | jq -r '.slotNo')
+current_slot=$(cardano-cli query tip $NETWORK_ARGUMENT | jq -r '.slot')
 percent=$(echo -e "scale=2\n$current_slot * 100 / $expected_slot" | bc)
 
 echo "slot ${current_slot}/${expected_slot} ${percent}%"

--- a/scripts/register_stake_address
+++ b/scripts/register_stake_address
@@ -90,7 +90,7 @@ fi
 # Generate protocol
 if [ -z "$COLD_CREATE" ]; then
     cardano-cli query protocol-parameters \
-        ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} \
+        ${NETWORK_ARGUMENT} \
         --out-file ${NODE_PATH}/staking/protocol.json
 else
     if [ ! -f "${NODE_PATH}/staking/protocol.json" ]; then

--- a/scripts/register_stake_pool
+++ b/scripts/register_stake_pool
@@ -95,7 +95,7 @@ fi
 # Generate protocol
 if [ -z "$COLD_CREATE" ]; then
     cardano-cli query protocol-parameters \
-        ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} \
+        ${NETWORK_ARGUMENT} \
         --out-file ${NODE_PATH}/staking/protocol.json
 else
     if [ ! -f "${NODE_PATH}/staking/protocol.json" ]; then

--- a/scripts/send_ada
+++ b/scripts/send_ada
@@ -50,7 +50,7 @@ if [[ "${WAIT_FOR_SYNC}" == "True" ]]; then
 fi
 
 cardano-cli query protocol-parameters \
-    ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} \
+    ${NETWORK_ARGUMENT} \
     --out-file ${NODE_PATH}/staking/protocol.json
 
 ADDRESS=$(cat payment.addr)

--- a/scripts/wallet_balance
+++ b/scripts/wallet_balance
@@ -29,4 +29,4 @@ fi
 
 ADDRESS=$(cat ${NODE_PATH}/staking/wallets/${WALLET}/payment.addr)
 
-cardano-cli query utxo ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} --address ${ADDRESS}
+cardano-cli query utxo ${NETWORK_ARGUMENT} --address ${ADDRESS}

--- a/scripts/withdraw_rewards
+++ b/scripts/withdraw_rewards
@@ -48,12 +48,12 @@ if [[ "${WAIT_FOR_SYNC}" == "True" ]]; then
 fi
 
 cardano-cli query protocol-parameters \
-    ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} \
+    ${NETWORK_ARGUMENT} \
     --out-file ${NODE_PATH}/staking/protocol.json
 
 ADDRESS=$(cat payment.addr)
 STAKE_ADDRESS=$(cat stake.addr)
-REWARD_BALANCE=$(cardano-cli query stake-address-info ${NETWORK_ARGUMENT} ${ERA_ARGUMENT} --address $(cat stake.addr) | jq -r ".[0].rewardAccountBalance")
+REWARD_BALANCE=$(cardano-cli query stake-address-info ${NETWORK_ARGUMENT} --address $(cat stake.addr) | jq -r ".[0].rewardAccountBalance")
 check_balance 200000 # Dummy transaction fee
 
 # Draft transaction


### PR DESCRIPTION
This PR includes changes required to run cardano-node v1.26.1.

I've successfully built the Docker image based on this PR.

```
root@3df9d2709ad9:/# cardano-cli --version
cardano-cli 1.26.1 - linux-x86_64 - ghc-8.10
git rev 62f38470098fc65e7de5a4b91e21e36ac30799f3
```

Once the cardano-node starts the DB migration immediately starts as well. Please see the release notes for details https://github.com/input-output-hk/cardano-node/releases/tag/1.26.1

On my local machine the DB migration took about 1.5h with a 3,1 GHz Intel Core i5. I suggest following the steps mentioned in the release notes to mitigation downtime when upgrading live nodes.