### PR TITLE
Bump node version to 1.26.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION="1.26.1"
+VERSION="1.26.2"
 docker build \
     --build-arg VERSION=${VERSION} \
     --tag arradev/cardano-node:${VERSION} \


### PR DESCRIPTION
> ... It ensures that block producing nodes do not unnecessarily re-evaluate the stake distribution at the epoch boundary.

https://github.com/input-output-hk/cardano-node/releases/tag/1.26.2